### PR TITLE
package: add `homepage` and `repository` fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,11 @@
     "javascript"
   ],
   "author": "davy@hackages.io",
+  "homepage": "https://github.com/hackages/hackages",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hackages/hackages.git"
+  },
   "license": "MIT",
   "dependencies": {
     "autoprefixer-loader": "^3.2.0",


### PR DESCRIPTION
It'll be easier to find the repository in [NPM package page](https://www.npmjs.com/package/hackages).